### PR TITLE
Add class on input , example : datepicker usage

### DIFF
--- a/bstable.js
+++ b/bstable.js
@@ -25,6 +25,7 @@ class BSTable {
       editableColumns: null,          // Index to editable columns. If null all td will be editable. Ex.: "1,2,3,4,5"
       $addButton: null,               // Jquery object of "Add" button
       onEdit: function() {},          // Called after editing (accept button clicked)
+      callbackOnEdit: function() {},          // Called after editing (editing button clicked)
       onBeforeDelete: function() {},  // Called before deletion
       onDelete: function() {},        // Called after deletion
       onAdd: function() {},           // Called when added a new row
@@ -159,10 +160,12 @@ class BSTable {
     if (this.currentlyEditingRow($currentRow)) return;    // not currently editing, return
     //Pone en modo de edición
     this._modifyEachColumn(this.options.editableColumns, $cols, function($td) {  // modify each column
+      let th = $td.closest('table').find('th').eq($td.index());
+      let th_class = th.attr("bstable-class");
       let content = $td.html();             // read content
       console.log(content);
       let div = '<div style="display: none;">' + content + '</div>';  // hide content (save for later use)
-      let input = '<input class="form-control input-sm"  data-original-value="' + content + '" value="' + content + '">';
+      let input = '<input class="form-control input-sm '+th_class+'" data-original-value="' + content + '" value="' + content + '">';
       $td.html(div + input);                // set content
     });
     this._actionsModeEdit(button);
@@ -271,7 +274,7 @@ class BSTable {
   _addOnClickEventsToActions() {
     let _this = this;
     // Add onclick events to each action button
-    this.table.find('tbody tr #bEdit').each(function() {let button = this; button.onclick = function() {_this._rowEdit(button)} });
+    this.table.find('tbody tr #bEdit').each(function() {let button = this; button.onclick = function() {_this._rowEdit(button); _this.options.callbackOnEdit();} });
     this.table.find('tbody tr #bDel').each(function() {let button = this; button.onclick = function() {_this._rowDelete(button)} });
     this.table.find('tbody tr #bAcep').each(function() {let button = this; button.onclick = function() {_this._rowAccept(button)} });
     this.table.find('tbody tr #bCanc').each(function() {let button = this; button.onclick = function() {_this._rowCancel(button)} });


### PR DESCRIPTION
My usage: bootstrap + tablesorter + datepicker + bstable  , Aim : edit with picker or classes on input, verifying value, picker....

I have a table displayed using tablesorter (ajax query), some column are "date's inputs". tbody is filled with ajax.
example : `<table><thead></thead><tbody></tbody><tfoot></tfoot></table>`

When success, i called : editableTable.refresh(); to enable this script in tablesorter.js.

As try, i wanted to add a date picker when editing on an input.

To realise that , bstables.js generate input form. To be able to aim them with jquery, and enable datepicker.js on those inputs i needed to add classes, but where? TH seems to be the best way. So I've done it with in my html code I've added `<th bstable-class="date"> in <thead>`
To get this value , i add those modifications :
```
      let th = $td.closest('table').find('th').eq($td.index());
      let th_class = th.attr("bstable-class");
```
+
```
     let input = '<input class="form-control input-sm '+th_class+'" data-original-value="' + content + '" value="' + content + '">';
```


Then i needed after edit (inputs created) to call:
```
 $('.date').each(function () {
                 $(this).datepicker({});
```
=>
```
 callbackOnEdit: function() {},          // Called after editing (editing button clicked)
```
+
```
this.table.find('tbody tr #bEdit').each(function() {let button = this; button.onclick = function() {_this._rowEdit(button); _this.options.callbackOnEdit();} });
```



With this modification, i can add class on inputs when editing based on the attr in `<th> column bstable-class="XXXX"`

So now, when i click on the edit button, and click on an input aimed to be a date, i can display a datepicker.

I hope this is a little best explained than in the issue.